### PR TITLE
fix: add a default endpoint to the provider

### DIFF
--- a/confidence/src/lib_test.rs
+++ b/confidence/src/lib_test.rs
@@ -25,7 +25,7 @@ mod tests {
     async fn setup_provider() -> open_feature::Client {
         let config = APIConfig {
             api_key: "".to_string(),
-            region: crate::Region::GLOBAL,
+            region: crate::Region::Global,
         };
         let mut mock_resolver = MockNetworkFlagResolver::new();
 
@@ -103,11 +103,12 @@ mod tests {
             .await
             .unwrap();
 
-
-
         assert_eq!(value.fields["integer-key"], open_feature::Value::Int(40));
         if let open_feature::Value::Struct(struct_value) = value.fields["struct-key"].clone() {
-            assert_eq!(struct_value.fields["integer-key"] , open_feature::Value::Int(23));
+            assert_eq!(
+                struct_value.fields["integer-key"],
+                open_feature::Value::Int(23)
+            );
         } else {
             assert_eq!(1, 0);
         }

--- a/confidence/src/models.rs
+++ b/confidence/src/models.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use typed_builder::TypedBuilder;
 use std::collections::HashMap;
+use typed_builder::TypedBuilder;
 
 #[derive(Debug)]
 pub enum ResolveError {
@@ -21,6 +21,7 @@ pub struct APIConfig {
 pub enum Region {
     US,
     EU,
+    Global,
 }
 
 #[allow(unused_variables)]
@@ -158,7 +159,7 @@ impl APIURL for Region {
         match self {
             Region::EU => "https://resolver.eu.confidence.dev".to_string(),
             Region::US => "https://resolver.us.confidence.dev".to_string(),
-            Region::GLOBAL => "https://resolver.confidence.dev".to_string(),
+            Region::Global => "https://resolver.confidence.dev".to_string(),
         }
     }
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -6,7 +6,7 @@ use open_feature::{EvaluationContext, OpenFeature};
 async fn main() {
     let api_config = APIConfig {
         api_key: "CLIENT_SECRET".to_string(),
-        region: Region::GLOBAL,
+        region: Region::Global,
     };
 
     let provider = ConfidenceProvider::builder()


### PR DESCRIPTION
Previously, the region would default to Europe. This PR is changing this to GLOBAL and is specifying a URL for that.