### PR TITLE
Add confidence-sdk-rust to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: confidence-sdk-rust
+  annotations:
+    github.com/project-slug: 'spotify/confidence-sdk-rust'
+spec:
+  type: library
+  lifecycle: production
+  owner: backstage-confidence


### PR DESCRIPTION

## TL;DR

This pull request registers confidence-sdk-rust, as a component in our Backstage Software Catalog.
It lists our team, backstage-confidence, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → http://localhost:3000/catalog

## What is Portal?

[Portal](https://backstage.spotify.com/products/portal) is an internal developer portal based on [Backstage](https://backstage.io/). It's goal is making developers' lives easier. Portal unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.
