### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with: 
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Run cargo check for lib
         run: cd confidence && cargo check
@@ -29,19 +25,15 @@ jobs:
       - name: Run cargo check for demo
         run: cd demo && cargo check
 
-  test: 
+  test:
     name: Test Suite
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with: 
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Run cargo test
         run: cd confidence && cargo test

--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -12,12 +12,12 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -36,7 +36,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:   
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,7 +10,7 @@ jobs:
 
     # Release-please creates a PR that tracks all changes
         steps: 
-        - uses: google-github-actions/release-please-action@v3
+        - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
           id: release
           with:
             release-type: simple
@@ -32,14 +32,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
           - name: Install stable toolchain
-            uses: actions-rs/toolchain@v1
-            with:
-              profile: minimal
-              toolchain: stable
-              override: true
+            uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
           - name: cargo login
             run: cargo login ${{ secrets.PUBLISH_CRATE_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable commit SHAs to mitigate supply chain attacks (e.g. TanStack "Mini Shai-Hulud")
- Replace archived `actions-rs/toolchain` with `dtolnay/rust-toolchain`

## Test plan
- [ ] CI passes with SHA-pinned actions
- [ ] Rust toolchain still installs correctly with dtolnay action

🤖 Generated with [Claude Code](https://claude.com/claude-code)