### PR TITLE
ci: update release-please-action from v3 to v4.1.1

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,12 +10,11 @@ jobs:
 
     # Release-please creates a PR that tracks all changes
         steps: 
-        - uses: google-github-actions/release-please-action@v3
+        - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
           id: release
           with:
             release-type: simple
-            command: manifest
-            default-branch: main
+            target-branch: main
 
         - name: Dump Release Please Output
           env:


### PR DESCRIPTION
## Summary
- Update `google-github-actions/release-please-action` from v3 to v4.1.1 (pinned SHA)
- Remove deprecated `command: manifest` input (v4 defaults to manifest when `release-type` is set)
- Rename `default-branch` to `target-branch` per v4 migration guide

Node.js 20 actions are deprecated starting June 16, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)